### PR TITLE
Change Dockerfile to run IPython Notebook Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,9 @@ FROM continuumio/miniconda:4.0.5
 COPY environment.yml /
 RUN /bin/bash -c "conda env create -f environment.yml"
 RUN rm environment.yml
-RUN /bin/bash -c "source activate strata"
-COPY anomaly/tripdata /
-COPY download.sh /
-RUN bash download.sh
+RUN mkdir /mnt/local
+RUN mkdir .jupyter
+COPY jupyter_notebook_config.py /.jupyter/
 
-EXPOSE 5000
-ENTRYPOINT echo "Success!"
+EXPOSE 8888
+CMD /bin/sh -c "/opt/conda/envs/strata/bin/ipython notebook /mnt/local"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This repo will be updated with example code and exercises in the coming weeks.  
 
 ## Installation
 
-All of the code we present uses Python 2.7.  A number of libraries beyond the standard library are used.  We recommend using the conda package manager to install the same versions that we are using, in a manner that won't interfere with your system packages.
+All of the code we present uses Python 2.7.  A number of libraries beyond the standard library are used.  We recommend using the conda package manager to install the same versions that we are using, in a manner that won't interfere with your system packages.  Alternatively, you can create a docker container from the provided Dockerfile that will contain all the necessary Python modules.
+
+### Conda
 
 You may install either the full [Anaconda Package Manager](https://docs.continuum.io/anaconda/install) or the smaller [Miniconda system](http://conda.pydata.org/docs/install/quick.html).  The former will provide you with over 720 packages, ready to use; the latter will makes it easy to download them when needed.  Once one of these are installed, you can install the packages we will be using into a separate environment with
 ```bash
@@ -24,7 +26,7 @@ or on Windows with
 > activate strata
 ```
 
-### Installation Alternative (Docker)
+### Docker
 
 If you run into trouble with the above installation, consider using Docker.
 
@@ -32,11 +34,19 @@ First, install [Docker](https://www.docker.com/) on your system.
 Then run these commands
 ```
 docker build .
-docker run [image-name]
 ```
-This will build a docker image from `Dockerfile` and automatically run conda installation in a "virtual" Linux environment.
-It outputs "Success!" upon success.
-**Note:** this has been tested on OSX.
+This will build a docker image from `Dockerfile` and automatically run conda installation in a "virtual" Linux environment.  Then you can launch the IPython Notebook Server inside of the container with
+```
+docker run -p 8888:8888 -v <absolute local path to this directory>:/mnt/local -t -i <image-name>
+```
+The notebooks should be available at http://localhost:8888/.  The specified directory will be mounted in the container at `/mnt/local`, which is being served by the Notebook Server.
+
+A shell inside of the container can be obtained with
+```
+docker run -p 8888:8888 -v <absolute local path to this directory>:/mnt/local -t -i <image-name> /bin/bash
+```
+
+**Note:** this has been tested on OS X and Ubuntu Linux.
 
 ## Data
 
@@ -51,4 +61,8 @@ We will be using the [MovieLens 10M data set](http://grouplens.org/datasets/movi
 We will be using data from the New York CitiBike program.  This is available in a number of zip files at https://s3.amazonaws.com/tripdata/index.html.  They can be easily downloaded with the provided script:
 ```bash
 $ ./download.sh
+```
+If you have installed the docker container, the script can be run like so:
+```
+docker run -v <absolute local path to this directory>:/mnt/local <image-name> /bin/sh -c 'cd /mnt/local && ./download.sh'
 ```

--- a/download.sh
+++ b/download.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 wget http://tripdata.s3.amazonaws.com/201307-citibike-tripdata.zip -P anomaly/tripdata/.
 wget http://tripdata.s3.amazonaws.com/201308-citibike-tripdata.zip -P anomaly/tripdata/.

--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -1,0 +1,6 @@
+c = get_config()
+c.IPKernelApp.matplotlib = 'inline'
+c.NotebookApp.open_browser = False
+c.NotebookApp.ip = '*'
+c.NotebookApp.port = 8888
+


### PR DESCRIPTION
Assuming I've done everything correctly, this Dockerfile should run the IPython server.  If you follow the instructions in the README, the port should be forwarded to localhost and the repo will be mounted as a volume on the container, to be served by the notebook server.  This allows people to explore the code and data without going through the container.  It also allows us to update the repo without needed to update the docker containers.

Some notes:
- There's no point in activating the strata environment in the Dockerfile, since that isn't sticky.  Instead, we use a path to the relevant ipython binary.
- We need an IPython config that accepts connections from other hosts.
- Use CMD rather than ENTRYPOINT in the Dockerfile to make it easier to run alternate commands.
- Use /bin/bash rather than /usr/bin/bash, so the script runs in the container.

I think this is a better solution, but I'd like a second opinion before I merge and announce.
